### PR TITLE
Add support for ESP8266

### DIFF
--- a/WoodsRFRemote/WoodsRFRemote.cpp
+++ b/WoodsRFRemote/WoodsRFRemote.cpp
@@ -1,6 +1,11 @@
 
 #include "WoodsRFRemote.h"
-#include <avr/pgmspace.h>
+
+#if (defined(__AVR__))
+#include <avr\pgmspace.h>
+#else
+#include <pgmspace.h>
+#endif
 
 #define NUM_CODES (2*NUM_RF_RC_OUTLETS)
 


### PR DESCRIPTION
<avr\pgmspace.h> is only available on AVR and throws compiler errors on ESP8266 boards.

<pgmspace.h> is an equivalent library for ESP.